### PR TITLE
V0.6.1+ bugfixes

### DIFF
--- a/BaldiLevelEditor/BasePlugin.cs
+++ b/BaldiLevelEditor/BasePlugin.cs
@@ -66,9 +66,9 @@ namespace BaldiLevelEditor
         public static CapsuleCollider playerColliderObject;
 
         public static Dictionary<string, Texture2D> lightmaps = new Dictionary<string, Texture2D>();
-        public static Shader tileStandardShader => Instance.assetMan.Get<Shader>("Shader Graphs/TileStandard");
+        public static Shader tileStandardShader => Instance.assetMan.Get<Shader>("Shader Graphs/TileStandard_AlphaClip");
         public static Shader tileMaskedShader => Instance.assetMan.Get<Shader>("Shader Graphs/MaskedStandard");
-        public static Shader tilePosterShader => Instance.assetMan.Get<Shader>("Shader Graphs/TileStandardWPoster");
+        public static Shader tilePosterShader => Instance.assetMan.Get<Shader>("Shader Graphs/TileStandardWPoster_AlphaClip");
         public static Material spriteMaterial;
         public static ElevatorScreen elevatorScreen;
         public static CoreGameManager coreGamePrefab;

--- a/BaldiLevelEditor/EditorSelector.cs
+++ b/BaldiLevelEditor/EditorSelector.cs
@@ -124,7 +124,7 @@ namespace BaldiLevelEditor
             MeshFilter filter = obj.AddComponent<MeshFilter>();
             filter.mesh = BaldiLevelEditorPlugin.Instance.assetMan.Get<Mesh>("Quad");
             MeshRenderer renderer = obj.AddComponent<MeshRenderer>();
-            renderer.material = new Material(BaldiLevelEditorPlugin.Instance.assetMan.Get<Shader>("Shader Graphs/TileStandard"));
+            renderer.material = new Material(BaldiLevelEditorPlugin.Instance.assetMan.Get<Shader>("Shader Graphs/TileStandard_AlphaClip"));
             renderer.material.SetTexture("_LightMap", Texture2D.whiteTexture);
             renderer.material.SetMainTexture(texture);
             obj.transform.SetParent(transform, false);

--- a/BaldiLevelEditor/EditorTile.cs
+++ b/BaldiLevelEditor/EditorTile.cs
@@ -48,7 +48,7 @@ namespace BaldiLevelEditor
             MeshFilter filter = obj.AddComponent<MeshFilter>();
             filter.mesh = BaldiLevelEditorPlugin.Instance.assetMan.Get<Mesh>("Quad");
             MeshRenderer renderer = obj.AddComponent<MeshRenderer>();
-            renderer.material = new Material(BaldiLevelEditorPlugin.Instance.assetMan.Get<Shader>("Shader Graphs/TileStandard"));
+            renderer.material = new Material(BaldiLevelEditorPlugin.tileStandardShader);
             renderer.material.SetTexture("_LightMap", Texture2D.whiteTexture);
             renderer.material.SetMainTexture(BaldiLevelEditorPlugin.Instance.assetMan.Get<Texture2D>("Grid"));
             obj.transform.SetParent(transform, false);

--- a/BaldiLevelEditor/LevelEditor/LevelEditor.cs
+++ b/BaldiLevelEditor/LevelEditor/LevelEditor.cs
@@ -93,8 +93,12 @@ namespace BaldiLevelEditor
             GameObject dummyObject = new GameObject();
             dummyObject.SetActive(false);
             RoomController dummyRC = dummyObject.AddComponent<RoomController>();
-            dummyRC.baseMat = new Material(BaldiLevelEditorPlugin.Instance.assetMan.Get<Shader>("Shader Graphs/TileStandard"));
-            dummyRC.posterMat = new Material(BaldiLevelEditorPlugin.Instance.assetMan.Get<Shader>("Shader Graphs/TileStandard"));
+            dummyRC.baseMat = new Material(BaldiLevelEditorPlugin.tileStandardShader);
+            dummyRC.posterMat = new Material(BaldiLevelEditorPlugin.tilePosterShader);
+
+            dummyRC.defaultAlphaMat = new Material(BaldiLevelEditorPlugin.tileStandardShader);
+            dummyRC.defaultAlphaPosterMap = new Material(BaldiLevelEditorPlugin.tileStandardShader);
+
             dummyRC.florTex = PlusLevelLoaderPlugin.TextureFromAlias(container.floor);
             dummyRC.wallTex = PlusLevelLoaderPlugin.TextureFromAlias(container.wall);
             dummyRC.ceilTex = PlusLevelLoaderPlugin.TextureFromAlias(container.ceiling);


### PR DESCRIPTION
Specifies the missing materials in the dummy RoomController when a texture atlas is to be created, as well as using the new AlphaClip version of the shader instead of the default, now opaque one.

Download:
[leveleditor-bb061.zip](https://github.com/user-attachments/files/16480920/leveleditor-bb061.zip)
