### PR TITLE
Fix opacity issues with the outside tile area in V0.6.1+

### DIFF
--- a/BaldiLevelEditor/BasePlugin.cs
+++ b/BaldiLevelEditor/BasePlugin.cs
@@ -66,9 +66,14 @@ namespace BaldiLevelEditor
         public static CapsuleCollider playerColliderObject;
 
         public static Dictionary<string, Texture2D> lightmaps = new Dictionary<string, Texture2D>();
-        public static Shader tileStandardShader => Instance.assetMan.Get<Shader>("Shader Graphs/TileStandard_AlphaClip");
+        public static Shader tileStandardShader => Instance.assetMan.Get<Shader>("Shader Graphs/TileStandard");
+        public static Shader tilePosterShader => Instance.assetMan.Get<Shader>("Shader Graphs/TileStandardWPoster");
+
+        public static Shader tileAlphaShader => Instance.assetMan.Get<Shader>("Shader Graphs/TileStandard_AlphaClip");
+        public static Shader tilePosterAlphaShader => Instance.assetMan.Get<Shader>("Shader Graphs/TileStandardWPoster_AlphaClip");
+
+
         public static Shader tileMaskedShader => Instance.assetMan.Get<Shader>("Shader Graphs/MaskedStandard");
-        public static Shader tilePosterShader => Instance.assetMan.Get<Shader>("Shader Graphs/TileStandardWPoster_AlphaClip");
         public static Material spriteMaterial;
         public static ElevatorScreen elevatorScreen;
         public static CoreGameManager coreGamePrefab;

--- a/BaldiLevelEditor/EditorSelector.cs
+++ b/BaldiLevelEditor/EditorSelector.cs
@@ -124,7 +124,7 @@ namespace BaldiLevelEditor
             MeshFilter filter = obj.AddComponent<MeshFilter>();
             filter.mesh = BaldiLevelEditorPlugin.Instance.assetMan.Get<Mesh>("Quad");
             MeshRenderer renderer = obj.AddComponent<MeshRenderer>();
-            renderer.material = new Material(BaldiLevelEditorPlugin.Instance.assetMan.Get<Shader>("Shader Graphs/TileStandard_AlphaClip"));
+            renderer.material = new Material(BaldiLevelEditorPlugin.tileAlphaShader);
             renderer.material.SetTexture("_LightMap", Texture2D.whiteTexture);
             renderer.material.SetMainTexture(texture);
             obj.transform.SetParent(transform, false);

--- a/BaldiLevelEditor/EditorTile.cs
+++ b/BaldiLevelEditor/EditorTile.cs
@@ -35,6 +35,8 @@ namespace BaldiLevelEditor
         void Start()
         {
             _tile = GameObject.Instantiate<Tile>(BaldiLevelEditorPlugin.Instance.tilePrefab, this.transform);
+            _tile.MeshRenderer.sharedMaterial.shader = BaldiLevelEditorPlugin.tileAlphaShader; // Use alpha shader to fix outside rendering bug
+
             GameObject clone = GameObject.Instantiate(_tile.Collider(Direction.North), transform);
             clone.transform.localPosition = Vector3.zero;
             clone.transform.eulerAngles = new Vector3(90f, 0f, 0f);
@@ -48,7 +50,7 @@ namespace BaldiLevelEditor
             MeshFilter filter = obj.AddComponent<MeshFilter>();
             filter.mesh = BaldiLevelEditorPlugin.Instance.assetMan.Get<Mesh>("Quad");
             MeshRenderer renderer = obj.AddComponent<MeshRenderer>();
-            renderer.material = new Material(BaldiLevelEditorPlugin.tileStandardShader);
+            renderer.material = new Material(BaldiLevelEditorPlugin.tileAlphaShader);
             renderer.material.SetTexture("_LightMap", Texture2D.whiteTexture);
             renderer.material.SetMainTexture(BaldiLevelEditorPlugin.Instance.assetMan.Get<Texture2D>("Grid"));
             obj.transform.SetParent(transform, false);

--- a/BaldiLevelEditor/LevelEditor/LevelEditor.cs
+++ b/BaldiLevelEditor/LevelEditor/LevelEditor.cs
@@ -96,8 +96,8 @@ namespace BaldiLevelEditor
             dummyRC.baseMat = new Material(BaldiLevelEditorPlugin.tileStandardShader);
             dummyRC.posterMat = new Material(BaldiLevelEditorPlugin.tilePosterShader);
 
-            dummyRC.defaultAlphaMat = new Material(BaldiLevelEditorPlugin.tileStandardShader);
-            dummyRC.defaultAlphaPosterMap = new Material(BaldiLevelEditorPlugin.tileStandardShader);
+            dummyRC.defaultAlphaMat = new Material(BaldiLevelEditorPlugin.tileAlphaShader);
+            dummyRC.defaultAlphaPosterMap = new Material(BaldiLevelEditorPlugin.tilePosterAlphaShader);
 
             dummyRC.florTex = PlusLevelLoaderPlugin.TextureFromAlias(container.floor);
             dummyRC.wallTex = PlusLevelLoaderPlugin.TextureFromAlias(container.wall);


### PR DESCRIPTION
The editor tiles now use the `Shader Graphs/TileStandard_AlphaClip` shader, fixing opacity issues with the outside area.

Temporary download link:
[leveleditor-opacityfix-bb061.zip](https://github.com/user-attachments/files/16487714/leveleditor-opacityfix-bb061.zip)
